### PR TITLE
Add Makefile and latexmk setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ erl_crash.dump
 *-html*
 *.epub
 *.mobi
+*.fdb_latexmk

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+LATEXMK      = latexmk
+LATEXMKFLAG += -halt-on-error -pdf
+
+SRC = text
+DEPS = 000-copyright.tex 101-diving.tex 103-overload.tex 105-runtime-metrics.tex 107-memory-leaks.tex 109-tracing.tex 001-introduction.tex 102-building.tex 104-connecting.tex 106-crash-dumps.tex 108-cpu.tex 201-conclusion.tex
+
+.PHONY: all clean
+
+all: $(SRC).pdf
+
+$(SRC).pdf: $(SRC).tex $(SRC).sty $(DEPS)
+	$(LATEXMK) $(LATEXMKFLAG) $<
+
+clean:
+	$(LATEXMK) -C

--- a/latexmkrc
+++ b/latexmkrc
@@ -1,0 +1,4 @@
+#!/usr/bin/env perl
+
+$pdflatex = 'pdflatex %O -synctex=1 -interaction=nonstopmode -shell-escape %B';
+$pdf_mode = 3;


### PR DESCRIPTION
Hello. I make a `Makefile` to build a PDF from command lines. You can build a PDF the following command:

```console
$ make
```

### What is `latexmk`?

[`latexmk`](https://ctan.org/pkg/latexmk?lang=en) is a popular build tool for LaTeX documents. It allows us to free some inconvenient for LaTeX build (for example, LaTeX requires that you compile some times but if you use `latexmk`, you can get a PDF by one compiling). `latexmk` file I was added in this PR is a setting file for `latexmk` command.

Regards.